### PR TITLE
tidied up list of manufacturer IDs

### DIFF
--- a/Src/fanet/radio/protocol.txt
+++ b/Src/fanet/radio/protocol.txt
@@ -495,18 +495,23 @@ Manufacturer IDs:
 0x07		SoftRF
 0x08		GXAircom
 0x09		Airtribune
-0x10		alfapilot
-...
-0x11		FANET+ (incl FLARM. Currently Skytraxx, Naviter, and Skybean)
-...
 0x0A		FLARM
+...
+0x10		alfapilot
+0x11		FANET+ (incl FLARM. Currently Skytraxx, Naviter, and Skybean)
 ...
 0x20		XC Tracer
 ...
-0xCB            Cloudbuddy
+0xCB		Cloudbuddy
+...
+0xDD		[reserved for compatibility issues]
+0xDE		[reserved for compatibility issues]
+0xDF		[reserved for compatibility issues]
 ...
 0xE0		OGN Tracker
 0xE4		4aviation
+...
+0xF0		[reserved for compatibility issues]
 ...
 0xFA		Various
 		0x0001-0x00FF		GetroniX
@@ -515,10 +520,3 @@ Manufacturer IDs:
 0xFD		Unregistered Devices
 0xFE		[Multicast]
 0xFF		[reserved]
-
-Reserved for compatibility issues:
-0xDD
-0xDE
-0xDF
-0xF0
-0x20


### PR DESCRIPTION
ID assignments are unchanged.

This PR sorts the IDs numerically (0x0A before 0x10), removes an inconsistency (0x20 was both assigned to XC Tracer and reserved for compatibility issues), and includes the "reserved for compatibility issues" IDs in the list for clarity.