### PR TITLE
Update protocol.txt - add new manufacturer ID for FlyBeeper devices

### DIFF
--- a/Src/fanet/radio/protocol.txt
+++ b/Src/fanet/radio/protocol.txt
@@ -498,6 +498,7 @@ Manufacturer IDs:
 0x08		GXAircom
 0x09		Airtribune
 0x0A		FLARM
+0x0B		FlyBeeper
 ...
 0x10		alfapilot
 0x11		FANET+ (incl FLARM. Currently Skytraxx, Naviter, and Skybean)


### PR DESCRIPTION
There are several ready-made devices with FANET support, ready for sale. 
FlyBeeper FANET
FlyBeeper F1
FlyBeeper F0
At the moment, the code 0хFC is used. Please reserve the code 0x0B for FlyBeeper devices.