### PR TITLE
Add manufacturer ID 0x0D: LYNKX

### DIFF
--- a/Src/fanet/radio/protocol.txt
+++ b/Src/fanet/radio/protocol.txt
@@ -500,6 +500,7 @@ Manufacturer IDs:
 0x0A		FLARM
 0x0B		FlyBeeper
 0x0C		Leaf Vario
+0x0D		LYNKX
 ...
 0x10		alfapilot
 0x11		FANET+ (incl FLARM. Currently Skytraxx, Naviter, and Skybean)


### PR DESCRIPTION
Hello, we are LYNKX (https://lynkx.eu), a French maker of outdoor safety beacons (LoRaWAN + GNSS). We are implementing FANET in our devices (tracking, messaging, ground tracking / distress) and would like to register manufacturer ID 0x0D, which appears to be unassigned.

Thanks for FANET and for maintaining the protocol!

Benoit — benoit@lynkx.eu